### PR TITLE
Improve calculate function

### DIFF
--- a/plugins/CommunityExtensions/ScreenUnits/ScreenUnits.js
+++ b/plugins/CommunityExtensions/ScreenUnits/ScreenUnits.js
@@ -16,12 +16,15 @@ numi.addUnit({
   "ratio" : basePx,
 });
 
-var calculate = function (original, base) {
-  if (!base) {
-    base = basePx;
-  }
-
-  return (original / base);
+/**
+ * Convert a pixel value to its rem representation.
+ *
+ * @param {number} pixels - Pixel value to convert.
+ * @param {number} [base=basePx] - Base pixel size for conversion.
+ * @returns {number} rem value
+ */
+function calculate(pixels, base = basePx) {
+  return pixels / base;
 }
 
 numi.addFunction({ "id": "toRem", "phrases": "toRem, convertRem" }, function(values) {

--- a/test/screenUnits.test.js
+++ b/test/screenUnits.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync(__dirname + '/../plugins/CommunityExtensions/ScreenUnits/ScreenUnits.js', 'utf8');
+const sandbox = {
+  numi: { addUnit: () => {}, addFunction: () => {} },
+};
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+
+const { calculate } = sandbox;
+
+assert.strictEqual(typeof calculate, 'function');
+assert.strictEqual(calculate(32), 2);
+assert.strictEqual(calculate(32, 32), 1);
+assert.strictEqual(calculate(0, 10), 0);
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- clarify calculate() logic with docs and default parameter
- add simple Node-based tests for ScreenUnits

## Testing
- `node test/screenUnits.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68449f09a4548322acf96f4e1ced7421