### PR TITLE
Add Arabic unit aliases plugin

### DIFF
--- a/plugins/CommunityExtensions/ArabicUnits/ArabicUnits.js
+++ b/plugins/CommunityExtensions/ArabicUnits/ArabicUnits.js
@@ -1,0 +1,82 @@
+// Arabic unit names extension
+// Adds Arabic aliases for common units
+
+numi.addUnit({
+  "id": "meter_ar",
+  "phrases": "متر, مترات",
+  "baseUnitId": "meter",
+  "format": "م",
+  "ratio": 1
+});
+
+numi.addUnit({
+  "id": "centimeter_ar",
+  "phrases": "سنتيمتر, سنتمتر, سم",
+  "baseUnitId": "meter",
+  "format": "سم",
+  "ratio": 0.01
+});
+
+numi.addUnit({
+  "id": "kilometer_ar",
+  "phrases": "كيلومتر, كيلومترات, كم",
+  "baseUnitId": "meter",
+  "format": "كم",
+  "ratio": 1000
+});
+
+numi.addUnit({
+  "id": "gram_ar",
+  "phrases": "غرام, جرام, جرامات",
+  "baseUnitId": "gram",
+  "format": "غ",
+  "ratio": 1
+});
+
+numi.addUnit({
+  "id": "kilogram_ar",
+  "phrases": "كيلوغرام, كيلوجرام, كغ",
+  "baseUnitId": "gram",
+  "format": "كغ",
+  "ratio": 1000
+});
+
+numi.addUnit({
+  "id": "liter_ar",
+  "phrases": "لتر, لترات",
+  "baseUnitId": "liter",
+  "format": "ل",
+  "ratio": 1
+});
+
+numi.addUnit({
+  "id": "milliliter_ar",
+  "phrases": "ملليلتر, ملل",
+  "baseUnitId": "liter",
+  "format": "مل",
+  "ratio": 0.001
+});
+
+numi.addUnit({
+  "id": "second_ar",
+  "phrases": "ثانية, ثواني",
+  "baseUnitId": "second",
+  "format": "ث",
+  "ratio": 1
+});
+
+numi.addUnit({
+  "id": "minute_ar",
+  "phrases": "دقيقة, دقائق",
+  "baseUnitId": "minute",
+  "format": "د",
+  "ratio": 1
+});
+
+numi.addUnit({
+  "id": "hour_ar",
+  "phrases": "ساعة, ساعات",
+  "baseUnitId": "hour",
+  "format": "س",
+  "ratio": 1
+});

--- a/plugins/CommunityExtensions/ArabicUnits/README.md
+++ b/plugins/CommunityExtensions/ArabicUnits/README.md
@@ -1,0 +1,14 @@
+# Arabic Units Extension for Numi
+
+## What is this extension for?
+Adds support for recognizing Arabic names of common units like meters, grams and liters.
+
+## Installation
+Simply download the `ArabicUnits.js` file to your Numi extensions directory.
+
+## How to use it
+```
+1 متر in cm
+5 كيلومتر in mile
+3 لتر in ml
+```


### PR DESCRIPTION
## Summary
- create new `ArabicUnits` community extension
- add Arabic aliases for common units like meter, gram, liter and time units
- document usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844fae5ff588322a13415332b069d5e